### PR TITLE
Prevent the cookiebanner from being visible when it is set to hidden

### DIFF
--- a/detail.php
+++ b/detail.php
@@ -151,6 +151,7 @@ $htmlLang = ' lang="' . $conf['lang'] . ( $lang['direction'] != 'ltr' ? '" dir="
 <?php include('tpl_footer.php') ?>
 		</footer>
 	</div>
+<?php my_cookiebanner("\t"); ?>
 	<div class="no"><?php tpl_indexerWebBug() /* provide DokuWiki housekeeping, required in all templates */ ?></div>
 	<div id="screen__mode" class="no"></div><?php /* helper to detect CSS media query in script.js */ ?>
 </body>

--- a/my_template.php
+++ b/my_template.php
@@ -546,15 +546,15 @@ function my_favicons($color = null) {
  */
 function my_cookiebanner($prefix = '') {
 
-	// if the cookie is already set, do nothing.
-	if (isset($_COOKIE['cookielaw'])) {
-		return;
-	}
-
 	// get the configuration settings:
 	$msg = tpl_getConf('cookiemsg', '(no message configured)');
 	$position = tpl_getConf('cookiepos', 'bottom');
 	$link = tpl_getConf('cookielink', 'about:cookies');
+
+	// if the cookie is already set or position is set to hide, do nothing.
+	if ( isset($_COOKIE['cookielaw']) or $position == 'hide') {
+		return;
+	}
 	
 	// output the HTML code:
 	echo $prefix . "<div id=\"cookiebanner\" class=\"cb_" . $position . "\">\n";


### PR DESCRIPTION
## Don't render the cookiebanner if cookiepos is set to hide

The cookie banner was still visible under certain conditions when `cookiepos` is set to `hide`. The banner was still rendered, but below the visible area. If the page is very short of the user zooms out of the page the banner becomes partially or completely visible.

![image](https://user-images.githubusercontent.com/9195687/148138694-bfbfdd76-2efd-42b5-890d-265ea738355b.png)

This small adjustment prevents the banner from being rendered at all if `cookiepos` is set to `hide`. To me a half visible cookiebanner seems quite awkward.

## Show the cookiebanner also on the details page

The details page was not displaying the cookie banner. This should make the banner visible on all pages.

PS: I hope creating such pull requests helps and doesn't create unnecessary work for you. If not please say so and I will refrain from creating new ones :D