### PR TITLE
Suggestion: Add a link to the user profile page

### DIFF
--- a/my_template.php
+++ b/my_template.php
@@ -352,17 +352,11 @@ function my_userinfo($prefix = '') {
 	foreach($items as $it) {
 		$typ = $it->getType();
 
-		// $it->getLabel() returns just the string "User profile" in the configured language.
-		// Using userlink() shows the full username instead and gives an indication of the currently logged in user account.k
-		if ($typ === 'profile') {
-		    $label = userlink();
-		} else {
-		    $label = $it->getLabel();
-		}
-
-		echo $prefix . "<li class=\"action $typ\"><a href=\"" . htmlentities($it->getLink()) . '" title="' . $it->getTitle() . '">' . $label . "</a></li>\n";
+		// special case for user profile, otherwise just write the items out:
+		echo $prefix . "<li class=\"action $typ\"><span class=\"sronly\">" . $lang['loggedinas'] .
+			' </span><a href="' . htmlentities($it->getLink()) . '" title="' . $it->getTitle() . '">' .
+			($typ === 'profile'? userlink() : $it->getLabel() ) . "</a></li>\n";
 	}
-
 }
 
 /**

--- a/my_template.php
+++ b/my_template.php
@@ -351,11 +351,19 @@ function my_userinfo($prefix = '') {
 	$items = (new \dokuwiki\Menu\UserMenu())->getItems();
 	foreach($items as $it) {
 		$typ = $it->getType();
+		
+		if ($typ === 'profile') { // special case for user profile:
+		
+			echo $prefix . '<li class="action profile"><span class="sronly">' . $lang['loggedinas'] .
+				' </span><a href="' . htmlentities($it->getLink()) . '" title="' . $it->getTitle() . '">' .
+				userlink() . "</a></li>\n";
 
-		// special case for user profile, otherwise just write the items out:
-		echo $prefix . "<li class=\"action $typ\"><span class=\"sronly\">" . $lang['loggedinas'] .
-			' </span><a href="' . htmlentities($it->getLink()) . '" title="' . $it->getTitle() . '">' .
-			($typ === 'profile'? userlink() : $it->getLabel() ) . "</a></li>\n";
+		} else {
+
+			echo $prefix . "<li class=\"action $typ\"><a href=\"" . htmlentities($it->getLink()) .
+				'" title="' . $it->getTitle() . '">' . ($typ === 'profile'? userlink() : $it->getLabel() ) .
+				"</a></li>\n";
+		}
 	}
 }
 

--- a/my_template.php
+++ b/my_template.php
@@ -351,11 +351,16 @@ function my_userinfo($prefix = '') {
 	$items = (new \dokuwiki\Menu\UserMenu())->getItems();
 	foreach($items as $it) {
 		$typ = $it->getType();
+
+		// $it->getLabel() returns just the string "User profile" in the configured language.
+		// Using userlink() shows the full username instead and gives an indication of the currently logged in user account.k
 		if ($typ === 'profile') {
-			echo $prefix . "<li class=\"action $typ\"><span class=\"sronly\">" . $lang['loggedinas'] . ' </span>' . userlink() . "</li>\n";
+		    $label = userlink();
 		} else {
-			echo $prefix . "<li class=\"action $typ\"><a href=\"" . htmlentities($it->getLink()) . '" title="' . $it->getTitle() . '">' . $it->getLabel() . "</a></li>\n";
+		    $label = $it->getLabel();
 		}
+
+		echo $prefix . "<li class=\"action $typ\"><a href=\"" . htmlentities($it->getLink()) . '" title="' . $it->getTitle() . '">' . $label . "</a></li>\n";
 	}
 
 }


### PR DESCRIPTION
In e.g. the default dokuwiki template the username displayed in the top right is a link to the profile page. This seems important to me as the profile page is where a non-admin user can change their password. As I'm not aware of a link to the profile page in the current state I suggest this adjustment:

Before:
![image](https://user-images.githubusercontent.com/9195687/148269778-41a8cfa2-e92d-4e70-a4b7-36c386f4d198.png)

With this change:
![image](https://user-images.githubusercontent.com/9195687/148269838-fc38b9f5-5279-4792-9e34-e9d7cd0f1290.png)

If the `profile` action is disabled in the dokuwiki configuration the whole entry disappears in the top right tool-bar. That seems to be the default dokuwiki behavior and has nothing to do with this suggestion.