### PR TITLE
Subscript and superscript fix

### DIFF
--- a/css/_footnotes.css
+++ b/css/_footnotes.css
@@ -20,13 +20,15 @@ body, div.footnotes {
 
 /* link to footnote inside the text */
 
-.dokuwiki sup { /* ignore superscript tags! */
+ /* .dokuwiki sup, .dokuwiki sub {ignore subscript and superscript tags!
 	vertical-align: baseline;
 	font-size: inherit;
-}
+} */
 .dokuwiki sup a.fn_top {
 	
 	& {
+		vertical-align: baseline;
+		font-size: inherit;
 		padding: 0 .5pt;
 		font-size: 0;text-decoration: none;
 	}
@@ -35,6 +37,7 @@ body, div.footnotes {
 		counter-increment: footnotes;
 		font-size: 1.1667rem;
 		font-weight: bold;
+		vertical-align: -.2em;
 	}
 }
 
@@ -75,6 +78,7 @@ div.insitu-footnote {
 			&::after {
 				content: counter(footnotes, decimal) '.';
 				counter-increment: footnotes;
+				font-variant-numeric: oldstyle-nums;
 				display: inline-block;
 				font-size: .972rem;
 				width: 2rem;

--- a/css/content.less
+++ b/css/content.less
@@ -65,16 +65,15 @@ body {
 	/* subscript and superscript */
 	sup, sub {
 		line-height: 1;
+		font-size: .6em;
 		font-weight: 600;
 		margin: 0 .1em;
 	}
 	sup {
-		vertical-align: .4em;
-		font-size: .67em;
+		vertical-align: .5em;
 	}
 	sub {
 		vertical-align: -.15em;
-		font-size: .67em;
 	}
 
 	/* lists: */

--- a/css/content.less
+++ b/css/content.less
@@ -62,6 +62,21 @@ body {
 		text-decoration: line-through rgba(255,0,0,.5) solid .1em;
 	}
 
+	/* subscript and superscript */
+	sup, sub {
+		line-height: 1;
+		font-weight: 600;
+		margin: 0 .1em;
+	}
+	sup {
+		vertical-align: .4em;
+		font-size: .67em;
+	}
+	sub {
+		vertical-align: -.15em;
+		font-size: .67em;
+	}
+
 	/* lists: */
 	ul, ol {
 		margin: 0 2em 1em 1em;

--- a/template.info.txt
+++ b/template.info.txt
@@ -1,7 +1,7 @@
 base     ad-hominem
 author   Sascha Leib
 email    ad@hominem.info
-date     2025-03-17
+date     2025-03-18
 name     Ad Hominem Template
 desc     A flexible, lightweight and modernised revision of the DokuWIki default template
 url      https://www.dokuwiki.org/template:ad-hominem


### PR DESCRIPTION
Quick fix for issue #63: Subscript and superscript should be handled separately from footnote signs.

Date is set to tomorrow as today's date was already taken.